### PR TITLE
Add Solax integration add-on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.pytest_cache/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
-# cantao_solax_add_on
+# CANTAO Solax Add-on
 
+Dieses Projekt liefert ein Python Add-on, das die Daten von Solax Wechselrichtern über die Solax Cloud API abruft und für CANTAO aufbereitet. Der Fokus liegt auf einer leichtgewichtigen Integration, die ohne tiefgreifende Änderungen am CANTAO-Kern auskommt.
+
+## Funktionen
+
+- Unterstützung der Solax Cloud API (v1 und v2)
+- Automatische Normalisierung der Messwerte in ein einheitliches Datenmodell
+- Konfigurierbare Transformationen zur Abbildung auf CANTAO-Metriken
+- CLI-Tool zum Abrufen oder direkten Weiterleiten der Daten an eine CANTAO Instanz
+- Robuste Fehlerbehandlung samt Logging
+
+## Installation
+
+```bash
+pip install .
+```
+
+Alternativ kann das Paket im Entwicklungsmodus installiert werden:
+
+```bash
+pip install -e .
+```
+
+## Konfiguration
+
+Die Konfiguration erfolgt über eine TOML-Datei. Eine Vorlage befindet sich in `examples/config.example.toml`.
+
+```toml
+[solax]
+base_url = "https://www.solaxcloud.com:9443"
+api_version = "v1"
+api_key = "<API_KEY>"
+serial_number = "<INVERTER_SERIAL>"
+site_id = "<PLANT_ID>"
+timeout = 10
+
+[cantao]
+base_url = "https://cantao.example.com"
+api_token = "<CANTAO_TOKEN>"
+metric_prefix = "solax"
+```
+
+## Verwendung
+
+### Daten abrufen
+
+```bash
+cantao-solax --config /pfad/zur/config.toml fetch
+```
+
+### Daten an CANTAO senden
+
+```bash
+cantao-solax --config /pfad/zur/config.toml push
+```
+
+Der Push-Befehl sendet die normalisierten Daten als JSON-Load an die konfigurierte CANTAO-Instanz. Auf CANTAO-Seite wird ein generischer `/api/v1/metrics`-Endpunkt angenommen.
+
+## Entwicklung
+
+- Tests ausführen: `pytest`
+- Linting (optional): `ruff check src`
+
+## Lizenz
+
+MIT

--- a/examples/config.example.toml
+++ b/examples/config.example.toml
@@ -1,0 +1,23 @@
+[solax]
+# Basis-URL der Solax Cloud API (inkl. Port)
+base_url = "https://www.solaxcloud.com:9443"
+# Unterstützte Werte: "v1" oder "v2"
+api_version = "v2"
+# Token-ID laut Solax-Dokumentation
+api_key = "0123456789abcdef0123456789abcdef"
+# Seriennummer (SN) des Wechselrichters
+serial_number = "AB1234567890"
+# Optional: UID/Plant-ID laut Dokumentation
+site_id = "12345"
+# Timeout für API Requests in Sekunden
+timeout = 10
+
+[cantao]
+# Adresse der CANTAO-Instanz
+base_url = "https://cantao.example.com"
+# Zugriffstoken für CANTAO
+api_token = "cantao-token"
+# Prefix, das allen Metriken vorangestellt wird
+metric_prefix = "solax"
+# Optional: Mapping einzelner Solax-Felder auf CANTAO-Schlüssel
+metric_mapping = { "yieldtoday" = "energy.today", "yieldtotal" = "energy.total" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cantao-solax-add-on"
+version = "0.1.0"
+description = "CANTAO add-on for integrating Solax inverter data via the Solax Cloud API."
+readme = "README.md"
+authors = [
+  {name = "OpenAI Assistant"}
+]
+license = {file = "LICENSE"}
+requires-python = ">=3.10"
+dependencies = [
+  "pydantic>=2.5.0"
+]
+
+[project.scripts]
+cantao-solax = "cantao_solax_add_on.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/src/cantao_solax_add_on/__init__.py
+++ b/src/cantao_solax_add_on/__init__.py
@@ -1,0 +1,14 @@
+"""CANTAO Solax Add-on."""
+
+from .client import CantaoSolaxClient
+from .config import CantaoConfig, SolaxConfig, load_config
+from .api import SolaxAPI, SolaxAPIError
+
+__all__ = [
+    "CantaoSolaxClient",
+    "CantaoConfig",
+    "SolaxConfig",
+    "SolaxAPI",
+    "SolaxAPIError",
+    "load_config",
+]

--- a/src/cantao_solax_add_on/api.py
+++ b/src/cantao_solax_add_on/api.py
@@ -1,0 +1,78 @@
+"""Low-level helpers for communicating with the Solax Cloud API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from typing import Any, Callable, Dict, Optional
+from urllib import error, request
+from urllib.parse import urlencode, urljoin
+
+from .config import SolaxConfig
+
+
+class SolaxAPIError(RuntimeError):
+    """Raised when the Solax API returns an error."""
+
+
+ResponseOpener = Callable[[request.Request], Any]
+
+
+@dataclass
+class SolaxAPI:
+    """Lightweight client for the Solax Cloud API."""
+
+    config: SolaxConfig
+    opener: ResponseOpener = field(default_factory=lambda: request.urlopen)
+
+    def _build_url(self, path: str) -> str:
+        api_root = f"/api/{self.config.api_version.strip('/')}/"
+        return urljoin(str(self.config.base_url), api_root + path.lstrip("/"))
+
+    def _request(self, path: str, extra_params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        params = self.config.to_request_params()
+        if extra_params:
+            params.update(extra_params)
+
+        url = self._build_url(path)
+        if params:
+            url = f"{url}?{urlencode(params)}"
+
+        req = request.Request(url, headers={"Accept": "application/json"})
+
+        try:
+            with self.opener(req) as resp:
+                body = resp.read().decode("utf-8")
+        except error.HTTPError as exc:  # pragma: no cover - network errors hard to reproduce
+            raise SolaxAPIError(f"HTTP error {exc.code} from Solax API") from exc
+        except error.URLError as exc:  # pragma: no cover - network errors hard to reproduce
+            raise SolaxAPIError(f"Could not reach Solax API: {exc.reason}") from exc
+
+        payload = json.loads(body)
+
+        # the API signals errors in several ways depending on the version
+        success_flag = payload.get("success")
+        if success_flag in (False, 0, "false", "0"):
+            raise SolaxAPIError(payload.get("exception") or "Solax API reported an error")
+
+        if "result" in payload:
+            return payload["result"]
+        if "data" in payload:
+            return payload["data"]
+
+        if isinstance(payload, dict):
+            return payload
+
+        raise SolaxAPIError("Unexpected response format from Solax API")
+
+    def get_realtime_data(self) -> Dict[str, Any]:
+        """Fetch the latest realtime metrics."""
+
+        endpoint = "getRealtimeInfo"
+        return self._request(endpoint)
+
+    def get_inverter_info(self) -> Dict[str, Any]:
+        """Fetch static inverter information if supported by the account."""
+
+        endpoint = "getInverterInfo"
+        return self._request(endpoint)

--- a/src/cantao_solax_add_on/cli.py
+++ b/src/cantao_solax_add_on/cli.py
@@ -1,0 +1,105 @@
+"""Command line interface for the CANTAO Solax add-on."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+
+from .api import SolaxAPI, SolaxAPIError
+from .client import CantaoPushError, CantaoSolaxClient
+from .config import AppConfig, load_config
+
+
+def _configure_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+
+def _build_client(config: AppConfig) -> CantaoSolaxClient:
+    api = SolaxAPI(config.solax)
+    return CantaoSolaxClient(api, config.cantao)
+
+
+def _cmd_fetch(client: CantaoSolaxClient, pretty: bool) -> int:
+    result = client.fetch_metrics()
+    metrics = result["metrics"]
+    output = {
+        "metrics": metrics,
+        "raw": result["raw"],
+    }
+    if pretty:
+        print(json.dumps(output, indent=2, sort_keys=True, ensure_ascii=False))
+    else:
+        print(json.dumps(output, separators=(",", ":"), ensure_ascii=False))
+    return 0
+
+
+def _cmd_push(client: CantaoSolaxClient, dry_run: bool, pretty: bool) -> int:
+    result = client.fetch_metrics()
+    metrics = result["metrics"]
+
+    if dry_run:
+        return _cmd_fetch(client, pretty)
+
+    client.push_metrics(metrics)
+    print(json.dumps({"status": "ok", "pushed_metrics": len(metrics)}))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="CANTAO Solax integration helper")
+    parser.add_argument("--config", required=True, help="Path to the configuration TOML file")
+    parser.add_argument("--log-level", default="INFO", help="Python logging level (default: INFO)")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    fetch_parser = subparsers.add_parser("fetch", help="Fetch realtime data and print it")
+    fetch_parser.add_argument("--pretty", action="store_true", help="Pretty print JSON output")
+
+    push_parser = subparsers.add_parser("push", help="Fetch realtime data and push it to CANTAO")
+    push_parser.add_argument("--pretty", action="store_true", help="Pretty print JSON output for dry-run")
+    push_parser.add_argument("--dry-run", action="store_true", help="Fetch data but do not push it")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    _configure_logging(args.log_level)
+
+    try:
+        config = load_config(args.config)
+        client = _build_client(config)
+
+        if args.command == "fetch":
+            return _cmd_fetch(client, args.pretty)
+        if args.command == "push":
+            return _cmd_push(client, args.dry_run, args.pretty)
+        parser.error("Unknown command")
+    except FileNotFoundError as exc:
+        logging.error("Configuration file not found: %%s", exc)
+        return 1
+    except ValueError as exc:
+        logging.error("Configuration error: %%s", exc)
+        return 1
+    except SolaxAPIError as exc:
+        logging.error("Solax API error: %%s", exc)
+        return 2
+    except CantaoPushError as exc:
+        logging.error("CANTAO push failed: %%s", exc)
+        return 3
+    except Exception as exc:  # pragma: no cover - safety net
+        logging.exception("Unexpected error: %%s", exc)
+        return 99
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/cantao_solax_add_on/client.py
+++ b/src/cantao_solax_add_on/client.py
@@ -1,0 +1,94 @@
+"""High level client coordinating Solax and CANTAO interactions."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict
+from urllib import request
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin
+
+from .api import SolaxAPI
+from .config import CantaoConfig
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CantaoPushError(RuntimeError):
+    """Raised when posting data to CANTAO fails."""
+
+
+Sender = Callable[[request.Request], Any]
+
+
+@dataclass
+class CantaoSolaxClient:
+    """Coordinator that retrieves data from Solax and forwards it to CANTAO."""
+
+    solax_api: SolaxAPI
+    cantao_config: CantaoConfig
+    sender: Sender = field(default_factory=lambda: request.urlopen)
+
+    def fetch_metrics(self) -> Dict[str, Any]:
+        """Fetch realtime data and normalise the payload."""
+
+        _LOGGER.debug("Fetching realtime data from Solax")
+        raw = self.solax_api.get_realtime_data()
+        normalised = self._normalise_payload(raw)
+        return {"raw": raw, "metrics": normalised}
+
+    def push_metrics(self, metrics: Dict[str, Any]) -> None:
+        """Push prepared metrics to CANTAO."""
+
+        if not self.cantao_config.is_push_enabled():
+            raise CantaoPushError("CANTAO push is not configured. Please set base_url and api_token.")
+
+        endpoint = "/api/v1/metrics"
+        url = urljoin(str(self.cantao_config.base_url), endpoint)
+        headers = {
+            "Authorization": f"Bearer {self.cantao_config.api_token}",
+            "Content-Type": "application/json",
+        }
+        payload = json.dumps({"metrics": metrics}).encode("utf-8")
+
+        _LOGGER.debug("Pushing %d metrics to CANTAO", len(metrics))
+
+        req = request.Request(url, data=payload, headers=headers, method="POST")
+
+        try:
+            with self.sender(req) as resp:
+                status = getattr(resp, "status", getattr(resp, "code", 200))
+                if status >= 400:
+                    body = resp.read().decode("utf-8", errors="ignore")
+                    _LOGGER.error("Failed to push metrics to CANTAO: %s", body)
+                    raise CantaoPushError(f"CANTAO responded with {status}")
+        except HTTPError as exc:
+            _LOGGER.error("HTTP error while pushing to CANTAO: %s", exc)
+            raise CantaoPushError(f"CANTAO responded with {exc.code}") from exc
+        except URLError as exc:
+            _LOGGER.error("Connection error while pushing to CANTAO: %s", exc)
+            raise CantaoPushError("Could not reach CANTAO endpoint") from exc
+
+    def _normalise_payload(self, raw: Dict[str, Any]) -> Dict[str, Any]:
+        mapping = self.cantao_config.metric_mapping
+        prefix = self.cantao_config.metric_prefix
+        metrics: Dict[str, Any] = {}
+
+        for key, value in raw.items():
+            if value in (None, ""):
+                continue
+            if isinstance(value, (int, float, bool)):
+                prepared_value = value
+            else:
+                try:
+                    prepared_value = float(value)
+                except (TypeError, ValueError):
+                    _LOGGER.debug("Skipping non-numeric field \"%s\"", key)
+                    continue
+
+            metric_key = mapping.get(key, f"{prefix}.{key}")
+            metrics[metric_key] = prepared_value
+
+        return metrics

--- a/src/cantao_solax_add_on/config.py
+++ b/src/cantao_solax_add_on/config.py
@@ -1,0 +1,91 @@
+"""Configuration handling for the CANTAO Solax add-on."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+import tomllib
+
+
+def _validate_url(url: str) -> str:
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError(f"Invalid URL: {url}")
+    return url
+
+
+@dataclass
+class SolaxConfig:
+    """Settings for accessing the Solax Cloud API."""
+
+    base_url: str
+    api_version: str = "v1"
+    api_key: str = field(default="")
+    serial_number: str = field(default="")
+    site_id: Optional[str] = None
+    timeout: int = 10
+
+    def __post_init__(self) -> None:
+        self.base_url = _validate_url(self.base_url)
+        if self.api_version not in {"v1", "v2"}:
+            raise ValueError("api_version must be 'v1' or 'v2'")
+        if not self.api_key:
+            raise ValueError("api_key must not be empty")
+        if not self.serial_number:
+            raise ValueError("serial_number must not be empty")
+        if self.timeout <= 0:
+            raise ValueError("timeout must be a positive integer")
+
+    def to_request_params(self) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"sn": self.serial_number}
+
+        if self.api_version == "v1":
+            params["tokenId"] = self.api_key
+            if self.site_id:
+                params["plantId"] = self.site_id
+        else:
+            params["accessToken"] = self.api_key
+            if self.site_id:
+                params["uid"] = self.site_id
+
+        return params
+
+
+@dataclass
+class CantaoConfig:
+    """Settings describing how data should be pushed to CANTAO."""
+
+    base_url: Optional[str] = None
+    api_token: Optional[str] = None
+    metric_prefix: str = "solax"
+    metric_mapping: Dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.base_url is not None:
+            self.base_url = _validate_url(self.base_url)
+        if self.metric_prefix.strip() == "":
+            raise ValueError("metric_prefix must not be empty")
+
+    def is_push_enabled(self) -> bool:
+        return bool(self.base_url and self.api_token)
+
+
+@dataclass
+class AppConfig:
+    solax: SolaxConfig
+    cantao: CantaoConfig = field(default_factory=CantaoConfig)
+
+
+def load_config(path: str | Path) -> AppConfig:
+    config_path = Path(path)
+    raw = tomllib.loads(config_path.read_text(encoding="utf-8"))
+
+    if "solax" not in raw:
+        raise ValueError("Missing [solax] section in configuration")
+
+    solax = SolaxConfig(**raw["solax"])
+    cantao = CantaoConfig(**raw.get("cantao", {}))
+    return AppConfig(solax=solax, cantao=cantao)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,71 @@
+from cantao_solax_add_on.client import CantaoSolaxClient, CantaoPushError
+from cantao_solax_add_on.config import CantaoConfig
+
+
+class DummySolaxAPI:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def get_realtime_data(self):
+        return self.payload
+
+
+class DummyResponse:
+    def __init__(self, status: int, body: bytes):  # pragma: no cover - trivial helper
+        self.status = status
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self._body
+
+
+class DummySender:
+    def __init__(self, status_code=200, body=b"{}"):  # pragma: no cover - trivial
+        self.status_code = status_code
+        self.body = body
+        self.calls = []
+
+    def __call__(self, req):
+        self.calls.append(req)
+        return DummyResponse(self.status_code, self.body)
+
+
+def test_normalise_payload():
+    payload = {"yieldtoday": "3.5", "yieldtotal": 1234.0, "temp": "not_a_number"}
+    api = DummySolaxAPI(payload)
+    cantao_config = CantaoConfig(metric_mapping={"yieldtoday": "energy.today"})
+    client = CantaoSolaxClient(api, cantao_config)
+
+    result = client.fetch_metrics()
+    assert result["metrics"] == {"energy.today": 3.5, "solax.yieldtotal": 1234.0}
+
+
+def test_push_requires_configuration():
+    api = DummySolaxAPI({})
+    cantao_config = CantaoConfig()
+    client = CantaoSolaxClient(api, cantao_config)
+
+    try:
+        client.push_metrics({})
+    except CantaoPushError as exc:
+        assert "not configured" in str(exc)
+    else:  # pragma: no cover - this path should never be reached
+        raise AssertionError("Expected CantaoPushError")
+
+
+def test_push_executes_post():
+    api = DummySolaxAPI({})
+    cantao_config = CantaoConfig(base_url="https://cantao.example", api_token="token")
+    sender = DummySender()
+    client = CantaoSolaxClient(api, cantao_config, sender=sender)
+
+    client.push_metrics({"solax.power": 100})
+    assert sender.calls
+    req = sender.calls[0]
+    assert req.get_header("Authorization") == "Bearer token"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,54 @@
+from cantao_solax_add_on.config import AppConfig, CantaoConfig, SolaxConfig, load_config
+
+
+def test_solax_request_params_v1():
+    config = SolaxConfig(
+        base_url="https://example.com",
+        api_version="v1",
+        api_key="token",
+        serial_number="sn",
+        site_id="plant",
+    )
+
+    params = config.to_request_params()
+    assert params == {"sn": "sn", "tokenId": "token", "plantId": "plant"}
+
+
+def test_solax_request_params_v2():
+    config = SolaxConfig(
+        base_url="https://example.com",
+        api_version="v2",
+        api_key="token",
+        serial_number="sn",
+        site_id="123",
+    )
+    params = config.to_request_params()
+    assert params == {"sn": "sn", "accessToken": "token", "uid": "123"}
+
+
+def test_cantao_push_flag():
+    config = CantaoConfig()
+    assert not config.is_push_enabled()
+
+    config = CantaoConfig(base_url="https://cantao.example", api_token="123")
+    assert config.is_push_enabled()
+
+
+def test_app_config_validation(tmp_path):
+    toml_content = """
+    [solax]
+    base_url = "https://example.com"
+    api_version = "v2"
+    api_key = "token"
+    serial_number = "sn"
+
+    [cantao]
+    base_url = "https://cantao.example"
+    api_token = "secret"
+    """
+    file_path = tmp_path / "config.toml"
+    file_path.write_text(toml_content)
+
+    config = load_config(file_path)
+    assert isinstance(config, AppConfig)
+    assert config.solax.api_version == "v2"


### PR DESCRIPTION
## Summary
- add Python package scaffolding for the CANTAO Solax integration including packaging metadata and example configuration
- implement configuration parsing, Solax Cloud API client, high-level CANTAO client, and CLI entry point for fetching or pushing metrics
- document usage/setup and cover core behaviour with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d65a7f0eec83279f798fc5592531ee