### PR TITLE
Add GitHub Actions CI and CLI integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .
+          python -m pip install pytest
+
+      - name: Run tests
+        run: pytest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,60 @@
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from cantao_solax_add_on import cli
+
+
+class DummyClient:
+    def __init__(self, metrics=None):
+        self.metrics = metrics or {"solax.power": 123}
+        self.push_calls = []
+
+    def fetch_metrics(self):
+        return {"metrics": self.metrics, "raw": {"power": 123}}
+
+    def push_metrics(self, metrics):
+        self.push_calls.append(metrics)
+
+
+@pytest.fixture()
+def sample_config(tmp_path: Path) -> Path:
+    config = tmp_path / "config.toml"
+    config.write_text(
+        textwrap.dedent(
+            """
+            [solax]
+            base_url = "https://api.example"
+            api_key = "abc"
+            serial_number = "sn123"
+            """
+        ).strip()
+    )
+    return config
+
+
+def test_cli_fetch_pretty(monkeypatch: pytest.MonkeyPatch, capsys, sample_config: Path):
+    dummy = DummyClient()
+    monkeypatch.setattr(cli, "_build_client", lambda config: dummy)
+
+    exit_code = cli.main(["--config", str(sample_config), "fetch", "--pretty"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr().out.strip()
+    payload = json.loads(captured)
+    assert payload["metrics"] == dummy.metrics
+    assert "raw" in payload
+
+
+def test_cli_push(monkeypatch: pytest.MonkeyPatch, capsys, sample_config: Path):
+    dummy = DummyClient()
+    monkeypatch.setattr(cli, "_build_client", lambda config: dummy)
+
+    exit_code = cli.main(["--config", str(sample_config), "push"])
+
+    assert exit_code == 0
+    assert dummy.push_calls == [dummy.metrics]
+    captured = capsys.readouterr().out.strip()
+    assert json.loads(captured) == {"status": "ok", "pushed_metrics": len(dummy.metrics)}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs the test suite on Python 3.10 through 3.12
- create CLI-focused unit tests to validate fetch and push commands using a sample configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d661859804832793dd75484550240d