### PR TITLE
Add Contao bundle for native Solax integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,46 @@ Das Add-on normalisiert Solax-Felder in metrische Schlüssel, die in CANTAO als 
 
 ## Installation
 
+### Contao-Integration
+
+Das Repository enthält nun ein vollwertiges Contao-Bundle (`cantao/solax-bundle`), das die komplette Kommunikation mit der Solax-Cloud innerhalb einer Contao-Instanz erledigt.
+
+1. Binden Sie das Bundle über Composer in Ihr Contao-Projekt ein:
+
+   ```bash
+   composer require cantao/solax-bundle:@dev
+   ```
+
+   > Hinweis: Beim lokalen Entwickeln kann das Bundle auch per `path`-Repository eingebunden werden.
+
+2. Führen Sie den Contao Manager oder `vendor/bin/contao-console contao:migrate` aus, damit die Tabelle `tl_solax_metric` angelegt wird.
+
+3. Hinterlegen Sie die Solax-Zugangsdaten in Ihrer Projektkonfiguration, z. B. in `config/config.yml`:
+
+   ```yaml
+   cantao_solax:
+     solax:
+       base_url: 'https://www.solaxcloud.com:9443'
+       api_version: 'v1'
+       api_key: '%env(SOLAX_API_KEY)%'
+       serial_number: '%env(SOLAX_SERIAL)%'
+       site_id: '%env(string:SOLAX_SITE_ID)%'
+       timeout: 10
+     cantao:
+       metric_prefix: 'solax'
+       metric_mapping:
+         yieldtoday: 'energy.today'
+         yieldtotal: 'energy.total'
+     storage:
+       table: 'tl_solax_metric'
+     cron:
+       interval: 'hourly' # möglich sind z. B. minutely, hourly, daily
+   ```
+
+4. Nach erfolgreicher Konfiguration steht unter **System → Cron** ein Job „SolaxSyncCron“ zur Verfügung. Dieser ruft in dem angegebenen Intervall die Werte ab und schreibt sie in die Tabelle `tl_solax_metric`. Die Datensätze lassen sich über das Backend (DCA `tl_solax_metric`) einsehen und weiterverarbeiten.
+
+### Python-Add-on
+
 ```bash
 pip install .
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "cantao/solax-bundle",
+    "description": "Contao bundle to synchronise Solax inverter metrics with CANTAO dashboards.",
+    "type": "contao-bundle",
+    "license": "MIT",
+    "require": {
+        "php": "^8.1",
+        "ext-json": "*",
+        "symfony/http-client": "^6.0",
+        "symfony/dependency-injection": "^6.0",
+        "symfony/config": "^6.0",
+        "symfony/http-kernel": "^6.0",
+        "psr/log": "^1.1 || ^2.0 || ^3.0",
+        "contao/core-bundle": "^5.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Cantao\\SolaxBundle\\": "php-src/"
+        }
+    },
+    "extra": {
+        "contao-manager-plugin": "Cantao\\SolaxBundle\\ContaoManager\\Plugin"
+    }
+}

--- a/contao/config/config.php
+++ b/contao/config/config.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+$GLOBALS['BE_MOD']['system']['solax_metrics'] = [
+    'tables' => ['tl_solax_metric'],
+];

--- a/contao/dca/tl_solax_metric.php
+++ b/contao/dca/tl_solax_metric.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+$GLOBALS['TL_DCA']['tl_solax_metric'] = [
+    'config' => [
+        'dataContainer' => 'Table',
+        'sql' => [
+            'keys' => [
+                'id' => 'primary',
+                'metric_key' => 'unique',
+            ],
+        ],
+    ],
+    'list' => [
+        'sorting' => [
+            'mode' => 1,
+            'fields' => ['metric_key'],
+            'flag' => 1,
+        ],
+        'label' => [
+            'fields' => ['metric_key', 'metric_value'],
+            'format' => '%s: %s',
+        ],
+        'global_operations' => [
+            'all' => [
+                'href' => 'act=select',
+                'class' => 'header_edit_all',
+                'attributes' => 'onclick="Backend.getScrollOffset();" accesskey="e"',
+            ],
+        ],
+        'operations' => [
+            'edit' => [
+                'href' => 'act=edit',
+                'icon' => 'edit.svg',
+            ],
+            'delete' => [
+                'href' => 'act=delete',
+                'icon' => 'delete.svg',
+                'attributes' => 'onclick="if(!confirm(\'TL_CONFIRM\'))return false;Backend.getScrollOffset();"',
+            ],
+        ],
+    ],
+    'palettes' => [
+        'default' => '{metric_legend},metric_key,metric_value,tstamp',
+    ],
+    'fields' => [
+        'id' => [
+            'sql' => 'int(10) unsigned NOT NULL auto_increment',
+        ],
+        'tstamp' => [
+            'sorting' => true,
+            'flag' => 6,
+            'sql' => "int(10) unsigned NOT NULL default '0'",
+        ],
+        'metric_key' => [
+            'label' => ['Metric Key', 'Unique identifier of the metric'],
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['maxlength' => 255, 'readonly' => true],
+            'sql' => "varchar(255) NOT NULL default ''",
+        ],
+        'metric_value' => [
+            'label' => ['Value', 'Latest metric value'],
+            'exclude' => true,
+            'inputType' => 'text',
+            'eval' => ['maxlength' => 255],
+            'sql' => "varchar(255) NOT NULL default ''",
+        ],
+    ],
+];

--- a/contao/languages/de/tl_solax_metric.php
+++ b/contao/languages/de/tl_solax_metric.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+$GLOBALS['TL_LANG']['tl_solax_metric']['metric_legend'] = 'Metriken';
+$GLOBALS['TL_LANG']['tl_solax_metric']['metric_key'] = ['Metrik-Schlüssel', 'Eindeutiger Schlüssel der Metrik.'];
+$GLOBALS['TL_LANG']['tl_solax_metric']['metric_value'] = ['Wert', 'Aktueller Wert des Solax-Wechselrichters.'];

--- a/contao/languages/en/tl_solax_metric.php
+++ b/contao/languages/en/tl_solax_metric.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+$GLOBALS['TL_LANG']['tl_solax_metric']['metric_legend'] = 'Metrics';
+$GLOBALS['TL_LANG']['tl_solax_metric']['metric_key'] = ['Metric key', 'Unique identifier of the metric.'];
+$GLOBALS['TL_LANG']['tl_solax_metric']['metric_value'] = ['Value', 'Latest value supplied by the Solax inverter.'];

--- a/contao/sql/tl_solax_metric.sql
+++ b/contao/sql/tl_solax_metric.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `tl_solax_metric` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `tstamp` int(10) unsigned NOT NULL default '0',
+  `metric_key` varchar(255) NOT NULL default '',
+  `metric_value` varchar(255) NOT NULL default '',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `metric_key` (`metric_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/php-src/CantaoSolaxBundle.php
+++ b/php-src/CantaoSolaxBundle.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cantao\SolaxBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class CantaoSolaxBundle extends Bundle
+{
+}

--- a/php-src/ContaoManager/Plugin.php
+++ b/php-src/ContaoManager/Plugin.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cantao\SolaxBundle\ContaoManager;
+
+use Cantao\SolaxBundle\CantaoSolaxBundle;
+use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
+use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
+use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
+use Contao\CoreBundle\ContaoCoreBundle;
+
+class Plugin implements BundlePluginInterface
+{
+    public function getBundles(ParserInterface $parser): array
+    {
+        return [
+            BundleConfig::create(CantaoSolaxBundle::class)
+                ->setLoadAfter([ContaoCoreBundle::class]),
+        ];
+    }
+}

--- a/php-src/Cron/SolaxSyncCron.php
+++ b/php-src/Cron/SolaxSyncCron.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cantao\SolaxBundle\Cron;
+
+use Cantao\SolaxBundle\Repository\MetricRepository;
+use Cantao\SolaxBundle\Service\MetricNormalizer;
+use Cantao\SolaxBundle\Service\SolaxClient;
+use Psr\Log\LoggerInterface;
+
+class SolaxSyncCron
+{
+    public function __construct(
+        private readonly SolaxClient $solaxClient,
+        private readonly MetricNormalizer $normalizer,
+        private readonly MetricRepository $repository,
+        private readonly LoggerInterface $logger,
+        private string $interval
+    ) {
+    }
+
+    public function __invoke(): void
+    {
+        try {
+            $raw = $this->solaxClient->fetchRealtimeData();
+            $metrics = $this->normalizer->normalise($raw);
+            $this->repository->storeMetrics($metrics);
+
+            $this->logger->info('Stored {count} Solax metrics.', [
+                'count' => count($metrics),
+            ]);
+        } catch (\Throwable $exception) {
+            $this->logger->error('Failed to synchronise Solax metrics: {message}', [
+                'message' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    public function getInterval(): string
+    {
+        return $this->interval;
+    }
+}

--- a/php-src/DependencyInjection/CantaoSolaxExtension.php
+++ b/php-src/DependencyInjection/CantaoSolaxExtension.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cantao\SolaxBundle\DependencyInjection;
+
+use Cantao\SolaxBundle\Cron\SolaxSyncCron;
+use Cantao\SolaxBundle\Repository\MetricRepository;
+use Cantao\SolaxBundle\Service\MetricNormalizer;
+use Cantao\SolaxBundle\Service\SolaxClient;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+
+class CantaoSolaxExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $container->setParameter('cantao_solax.solax_config', $config['solax']);
+        $container->setParameter('cantao_solax.metric_mapping', $config['cantao']['metric_mapping']);
+        $container->setParameter('cantao_solax.metric_prefix', $config['cantao']['metric_prefix']);
+        $container->setParameter('cantao_solax.cron_interval', $config['cron']['interval']);
+
+        $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('services.php');
+
+        $container->getDefinition(SolaxClient::class)
+            ->setArgument('$config', '%cantao_solax.solax_config%');
+
+        $container->getDefinition(MetricNormalizer::class)
+            ->setArgument('$mapping', '%cantao_solax.metric_mapping%')
+            ->setArgument('$prefix', '%cantao_solax.metric_prefix%');
+
+        $cronDefinition = $container->getDefinition(SolaxSyncCron::class);
+        $cronDefinition
+            ->setArgument('$interval', '%cantao_solax.cron_interval%');
+        $cronDefinition->clearTag('contao.cronjob');
+        $cronDefinition->addTag('contao.cronjob', ['interval' => $config['cron']['interval']]);
+
+        if ($container->hasDefinition(MetricRepository::class)) {
+            $container->getDefinition(MetricRepository::class)
+                ->setArgument('$tableName', $config['storage']['table']);
+        }
+    }
+}

--- a/php-src/DependencyInjection/Configuration.php
+++ b/php-src/DependencyInjection/Configuration.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cantao\SolaxBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('cantao_solax');
+        $root = $treeBuilder->getRootNode();
+
+        $root
+            ->children()
+                ->arrayNode('solax')
+                    ->isRequired()
+                    ->children()
+                        ->scalarNode('base_url')->isRequired()->cannotBeEmpty()->end()
+                        ->scalarNode('api_version')->defaultValue('v1')->validate()
+                            ->ifNotInArray(['v1', 'v2'])
+                            ->thenInvalid('Solax API version must be either "v1" or "v2".')
+                        ->end()
+                        ->scalarNode('api_key')->isRequired()->cannotBeEmpty()->end()
+                        ->scalarNode('serial_number')->isRequired()->cannotBeEmpty()->end()
+                        ->scalarNode('site_id')->defaultNull()->end()
+                        ->integerNode('timeout')->defaultValue(10)->min(1)->end()
+                    ->end()
+                ->end()
+                ->arrayNode('cantao')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('metric_prefix')->defaultValue('solax')->cannotBeEmpty()->end()
+                        ->arrayNode('metric_mapping')
+                            ->useAttributeAsKey('source')
+                            ->scalarPrototype()->end()
+                            ->defaultValue([])
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('storage')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('table')->defaultValue('tl_solax_metric')->cannotBeEmpty()->end()
+                    ->end()
+                ->end()
+                ->arrayNode('cron')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('interval')->defaultValue('hourly')->cannotBeEmpty()->end()
+                    ->end()
+                ->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/php-src/Repository/MetricRepository.php
+++ b/php-src/Repository/MetricRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cantao\SolaxBundle\Repository;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+
+class MetricRepository
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private string $tableName
+    ) {
+    }
+
+    /**
+     * @param array<string, float|int|bool> $metrics
+     */
+    public function storeMetrics(array $metrics): void
+    {
+        $timestamp = time();
+
+        foreach ($metrics as $key => $value) {
+            $this->connection->delete($this->tableName, ['metric_key' => $key]);
+
+            $this->connection->insert(
+                $this->tableName,
+                [
+                    'tstamp' => $timestamp,
+                    'metric_key' => $key,
+                    'metric_value' => (string) $value,
+                ],
+                [
+                    ParameterType::INTEGER,
+                    ParameterType::STRING,
+                    ParameterType::STRING,
+                ]
+            );
+        }
+    }
+}

--- a/php-src/Resources/config/services.php
+++ b/php-src/Resources/config/services.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Cantao\SolaxBundle\Cron\SolaxSyncCron;
+use Cantao\SolaxBundle\Repository\MetricRepository;
+use Cantao\SolaxBundle\Service\MetricNormalizer;
+use Cantao\SolaxBundle\Service\SolaxClient;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $configurator): void {
+    $services = $configurator->services();
+
+    $services
+        ->set(SolaxClient::class)
+        ->args([
+            service('http_client'),
+            service(LoggerInterface::class),
+            [],
+        ]);
+
+    $services
+        ->set(MetricNormalizer::class)
+        ->args([
+            [],
+            'solax',
+        ]);
+
+    $services
+        ->set(MetricRepository::class)
+        ->args([
+            service('database_connection'),
+            'tl_solax_metric',
+        ]);
+
+    $services
+        ->set(SolaxSyncCron::class)
+        ->args([
+            service(SolaxClient::class),
+            service(MetricNormalizer::class),
+            service(MetricRepository::class),
+            service(LoggerInterface::class),
+            'hourly',
+        ])
+        ->tag('contao.cronjob', ['interval' => 'hourly']);
+};

--- a/php-src/Service/MetricNormalizer.php
+++ b/php-src/Service/MetricNormalizer.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cantao\SolaxBundle\Service;
+
+class MetricNormalizer
+{
+    /**
+     * @param array<string, string> $mapping
+     */
+    public function __construct(
+        private array $mapping,
+        private string $prefix
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @return array<string, float|int|bool>
+     */
+    public function normalise(array $payload): array
+    {
+        $metrics = [];
+
+        foreach ($payload as $field => $value) {
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            if (is_bool($value) || is_int($value) || is_float($value)) {
+                $normalised = $value;
+            } else {
+                if (is_numeric($value)) {
+                    $normalised = (float) $value;
+                } else {
+                    continue;
+                }
+            }
+
+            $metricKey = $this->mapping[$field] ?? sprintf('%s.%s', $this->prefix, $field);
+            $metrics[$metricKey] = $normalised;
+        }
+
+        return $metrics;
+    }
+}

--- a/php-src/Service/SolaxClient.php
+++ b/php-src/Service/SolaxClient.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cantao\SolaxBundle\Service;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class SolaxClient
+{
+    private array $config;
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly LoggerInterface $logger,
+        array $config
+    ) {
+        $this->config = $config;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function fetchRealtimeData(): array
+    {
+        $endpoint = 'getRealtimeInfo';
+        $url = rtrim((string) $this->config['base_url'], '/') . '/api/' . trim((string) $this->config['api_version'], '/') . '/' . $endpoint;
+
+        $options = [
+            'query' => $this->buildQueryParameters(),
+            'timeout' => (int) ($this->config['timeout'] ?? 10),
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
+        ];
+
+        try {
+            $response = $this->httpClient->request('GET', $url, $options);
+            $data = $response->toArray(false);
+        } catch (ClientExceptionInterface | RedirectionExceptionInterface | ServerExceptionInterface | TransportExceptionInterface $exception) {
+            $this->logger->error('Could not fetch realtime data from Solax: {message}', [
+                'message' => $exception->getMessage(),
+            ]);
+
+            throw new \RuntimeException('Solax API request failed', 0, $exception);
+        }
+
+        if (isset($data['success']) && in_array($data['success'], [false, 0, 'false', '0'], true)) {
+            $message = $data['exception'] ?? 'Solax API reported an error.';
+            $this->logger->error('Solax API returned an error: {message}', ['message' => $message]);
+            throw new \RuntimeException($message);
+        }
+
+        if (isset($data['result']) && is_array($data['result'])) {
+            return $data['result'];
+        }
+
+        if (isset($data['data']) && is_array($data['data'])) {
+            return $data['data'];
+        }
+
+        if (is_array($data)) {
+            return $data;
+        }
+
+        $this->logger->error('Solax API responded with an unexpected payload.');
+        throw new \RuntimeException('Unexpected response format from Solax API.');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function buildQueryParameters(): array
+    {
+        $params = [
+            'sn' => $this->config['serial_number'],
+        ];
+
+        if (($this->config['api_version'] ?? 'v1') === 'v1') {
+            $params['tokenId'] = $this->config['api_key'];
+            if (!empty($this->config['site_id'])) {
+                $params['plantId'] = $this->config['site_id'];
+            }
+        } else {
+            $params['accessToken'] = $this->config['api_key'];
+            if (!empty($this->config['site_id'])) {
+                $params['uid'] = $this->config['site_id'];
+            }
+        }
+
+        return array_map(static fn ($value): string => (string) $value, $params);
+    }
+}


### PR DESCRIPTION
## Summary
- add a Contao bundle with service wiring, cron job and Solax API client for native metric synchronisation
- provide backend configuration, database schema and translations for storing inverter metrics inside Contao
- document the new Contao installation path in the README alongside the existing Python add-on usage

## Testing
- pytest
- for file in $(git ls-files --others --exclude-standard '*.php'); do php -l "$file"; done

------
https://chatgpt.com/codex/tasks/task_e_68ec878672a883279d0da9a38fa7a7f4