### PR TITLE
Secure Solax credentials and add CI packaging stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ erhalten bleiben.
 - Im Abschnitt **Solax Fake-Daten** lässt sich ein Fake-Data-Modus aktivieren. Er simuliert PV-Werte anhand der aktuellen Uhrzeit,
   Sonnenauf- und -untergang sowie einer konfigurierbaren Wolkenwahrscheinlichkeit. Standort (Breiten- und Längengrad), Peakleistung
   und Grundlast können angepasst werden.
-- Im Abschnitt **Solax Zugangsdaten** werden die echten API-Zugangsdaten hinterlegt. Sobald gültige Anmeldedaten vorhanden sind und
-  der Fake-Data-Modus deaktiviert ist, ruft das Bundle automatisch Live-Daten aus der Solax-Cloud ab.
+- Im Abschnitt **Solax Zugangsdaten** werden die echten API-Zugangsdaten hinterlegt. Die Felder für API-Schlüssel, Seriennummer und
+  UID/Plant-ID werden verschlüsselt gespeichert und lassen sich ohne Konfigurationsdateien direkt im Backend pflegen. Sobald gültige
+  Anmeldedaten vorhanden sind und der Fake-Data-Modus deaktiviert ist, ruft das Bundle automatisch Live-Daten aus der Solax-Cloud ab.
 
 Ohne aktivierten Fake-Data-Modus und ohne hinterlegte Zugangsdaten überspringt der Cronjob die Synchronisation und protokolliert
 einen Hinweis im System-Log.

--- a/cantao_build_backend.py
+++ b/cantao_build_backend.py
@@ -1,43 +1,83 @@
-"""Minimal PEP 517 backend used for CI compatibility."""
+"""Minimal PEP 517 backend so CI can run ``pip install .`` without external deps."""
 
 from __future__ import annotations
 
 import io
 import tarfile
+import tempfile
 import zipfile
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Mapping, Sequence
+from typing import Iterable, Mapping, Sequence
 
-_NAME = "cantao-solax-bundle"
-_VERSION = "0.0.0"
-_SUMMARY = (
-    "Placeholder package so CI 'pip install .' succeeds for the PHP bundle."
+ROOT = Path(__file__).resolve().parent
+PACKAGE_ROOT = ROOT / "cantao_solax_placeholder"
+EXTRA_FILES = [
+    ROOT / "pyproject.toml",
+    ROOT / "cantao_build_backend.py",
+    ROOT / "setup.py",
+    ROOT / "README.md",
+]
+
+
+@dataclass(frozen=True)
+class Project:
+    name: str
+    version: str
+    summary: str
+    license: str
+
+    @property
+    def dist_info(self) -> str:
+        return f"{self.name.replace('-', '_')}-{self.version}.dist-info"
+
+    def metadata_text(self) -> str:
+        return (
+            "Metadata-Version: 2.1\n"
+            f"Name: {self.name}\n"
+            f"Version: {self.version}\n"
+            f"Summary: {self.summary}\n"
+            f"License: {self.license}\n"
+        )
+
+    def wheel_text(self) -> str:
+        return (
+            "Wheel-Version: 1.0\n"
+            "Generator: cantao-solax-backend (custom backend)\n"
+            "Root-Is-Purelib: true\n"
+            "Tag: py3-none-any\n"
+        )
+
+
+PROJECT = Project(
+    name="cantao-solax-bundle",
+    version="0.0.0",
+    summary="Placeholder package so CI 'pip install .' succeeds for the PHP bundle.",
+    license="MIT",
 )
-_LICENSE = "MIT"
 
 
-def _dist_info_dir() -> str:
-    normalized = _NAME.replace("-", "_")
-    return f"{normalized}-{_VERSION}.dist-info"
+def _package_files() -> Iterable[tuple[Path, str]]:
+    for path in PACKAGE_ROOT.rglob("*"):
+        if path.is_file():
+            yield path, str(path.relative_to(ROOT))
+
+    for path in EXTRA_FILES:
+        if path.exists() and path.is_file():
+            yield path, path.name
 
 
-def _metadata() -> str:
-    return (
-        "Metadata-Version: 2.1\n"
-        f"Name: {_NAME}\n"
-        f"Version: {_VERSION}\n"
-        f"Summary: {_SUMMARY}\n"
-        f"License: {_LICENSE}\n"
-    )
-
-
-def _wheel_file() -> str:
-    return (
-        "Wheel-Version: 1.0\n"
-        "Generator: cantao-solax-placeholder (custom backend)\n"
-        "Root-Is-Purelib: true\n"
-        "Tag: py3-none-any\n"
-    )
+def _write_dist_info(base: Path) -> list[str]:
+    dist_info = base / PROJECT.dist_info
+    dist_info.mkdir(parents=True, exist_ok=True)
+    (dist_info / "METADATA").write_text(PROJECT.metadata_text(), encoding="utf-8")
+    (dist_info / "WHEEL").write_text(PROJECT.wheel_text(), encoding="utf-8")
+    (dist_info / "RECORD").write_text("", encoding="utf-8")
+    return [
+        f"{PROJECT.dist_info}/METADATA",
+        f"{PROJECT.dist_info}/WHEEL",
+        f"{PROJECT.dist_info}/RECORD",
+    ]
 
 
 def get_requires_for_build_wheel(config_settings: Mapping[str, Sequence[str]] | None = None) -> list[str]:
@@ -51,13 +91,9 @@ def get_requires_for_build_sdist(config_settings: Mapping[str, Sequence[str]] | 
 def prepare_metadata_for_build_wheel(
     metadata_directory: str, config_settings: Mapping[str, Sequence[str]] | None = None
 ) -> str:
-    path = Path(metadata_directory)
-    dist_info = path / _dist_info_dir()
-    dist_info.mkdir(parents=True, exist_ok=True)
-    (dist_info / "METADATA").write_text(_metadata(), encoding="utf-8")
-    (dist_info / "WHEEL").write_text(_wheel_file(), encoding="utf-8")
-    (dist_info / "RECORD").write_text("", encoding="utf-8")
-    return dist_info.name
+    base = Path(metadata_directory)
+    _write_dist_info(base)
+    return PROJECT.dist_info
 
 
 def build_wheel(
@@ -67,14 +103,26 @@ def build_wheel(
 ) -> str:
     wheel_dir = Path(wheel_directory)
     wheel_dir.mkdir(parents=True, exist_ok=True)
-    filename = f"{_NAME.replace('-', '_')}-{_VERSION}-py3-none-any.whl"
-    dist_info = _dist_info_dir()
-    wheel_path = wheel_dir / filename
+    filename = f"{PROJECT.name.replace('-', '_')}-{PROJECT.version}-py3-none-any.whl"
+    archive_path = wheel_dir / filename
 
-    with zipfile.ZipFile(wheel_path, "w") as archive:
-        archive.writestr(f"{dist_info}/METADATA", _metadata())
-        archive.writestr(f"{dist_info}/WHEEL", _wheel_file())
-        archive.writestr(f"{dist_info}/RECORD", "")
+    with zipfile.ZipFile(archive_path, "w") as archive, tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        record_entries: list[str] = []
+
+        for file_path, arcname in _package_files():
+            archive.write(file_path, arcname)
+            record_entries.append(f"{arcname},,\n")
+
+        dist_info_dir = tmp_path / PROJECT.dist_info
+        _write_dist_info(tmp_path)
+        for file_path in dist_info_dir.rglob("*"):
+            if file_path.is_file():
+                arcname = f"{PROJECT.dist_info}/{file_path.name}"
+                archive.write(file_path, arcname)
+                record_entries.append(f"{arcname},,\n")
+
+        archive.writestr(f"{PROJECT.dist_info}/RECORD", "".join(record_entries))
 
     return filename
 
@@ -85,14 +133,21 @@ def build_sdist(
 ) -> str:
     sdist_dir = Path(sdist_directory)
     sdist_dir.mkdir(parents=True, exist_ok=True)
-    filename = f"{_NAME}-{_VERSION}.tar.gz"
-    sdist_path = sdist_dir / filename
+    filename = f"{PROJECT.name}-{PROJECT.version}.tar.gz"
+    archive_path = sdist_dir / filename
 
-    with tarfile.open(sdist_path, "w:gz") as archive:
-        info = tarfile.TarInfo(name=f"{_NAME}-{_VERSION}/PKG-INFO")
-        data = _metadata().encode("utf-8")
-        info.size = len(data)
-        archive.addfile(info, io.BytesIO(data))
+    with tarfile.open(archive_path, "w:gz") as archive:
+        base_folder = Path(f"{PROJECT.name}-{PROJECT.version}")
+        for file_path, arcname in _package_files():
+            target = base_folder / arcname
+            info = archive.gettarinfo(str(file_path), arcname=str(target))
+            with file_path.open("rb") as handle:
+                archive.addfile(info, handle)
+
+        metadata = PROJECT.metadata_text().encode("utf-8")
+        info = tarfile.TarInfo(str(base_folder / "PKG-INFO"))
+        info.size = len(metadata)
+        archive.addfile(info, io.BytesIO(metadata))
 
     return filename
 

--- a/cantao_build_backend.py
+++ b/cantao_build_backend.py
@@ -1,0 +1,111 @@
+"""Minimal PEP 517 backend used for CI compatibility."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import Mapping, Sequence
+
+_NAME = "cantao-solax-bundle"
+_VERSION = "0.0.0"
+_SUMMARY = (
+    "Placeholder package so CI 'pip install .' succeeds for the PHP bundle."
+)
+_LICENSE = "MIT"
+
+
+def _dist_info_dir() -> str:
+    normalized = _NAME.replace("-", "_")
+    return f"{normalized}-{_VERSION}.dist-info"
+
+
+def _metadata() -> str:
+    return (
+        "Metadata-Version: 2.1\n"
+        f"Name: {_NAME}\n"
+        f"Version: {_VERSION}\n"
+        f"Summary: {_SUMMARY}\n"
+        f"License: {_LICENSE}\n"
+    )
+
+
+def _wheel_file() -> str:
+    return (
+        "Wheel-Version: 1.0\n"
+        "Generator: cantao-solax-placeholder (custom backend)\n"
+        "Root-Is-Purelib: true\n"
+        "Tag: py3-none-any\n"
+    )
+
+
+def get_requires_for_build_wheel(config_settings: Mapping[str, Sequence[str]] | None = None) -> list[str]:
+    return []
+
+
+def get_requires_for_build_sdist(config_settings: Mapping[str, Sequence[str]] | None = None) -> list[str]:
+    return []
+
+
+def prepare_metadata_for_build_wheel(
+    metadata_directory: str, config_settings: Mapping[str, Sequence[str]] | None = None
+) -> str:
+    path = Path(metadata_directory)
+    dist_info = path / _dist_info_dir()
+    dist_info.mkdir(parents=True, exist_ok=True)
+    (dist_info / "METADATA").write_text(_metadata(), encoding="utf-8")
+    (dist_info / "WHEEL").write_text(_wheel_file(), encoding="utf-8")
+    (dist_info / "RECORD").write_text("", encoding="utf-8")
+    return dist_info.name
+
+
+def build_wheel(
+    wheel_directory: str,
+    config_settings: Mapping[str, Sequence[str]] | None = None,
+    metadata_directory: str | None = None,
+) -> str:
+    wheel_dir = Path(wheel_directory)
+    wheel_dir.mkdir(parents=True, exist_ok=True)
+    filename = f"{_NAME.replace('-', '_')}-{_VERSION}-py3-none-any.whl"
+    dist_info = _dist_info_dir()
+    wheel_path = wheel_dir / filename
+
+    with zipfile.ZipFile(wheel_path, "w") as archive:
+        archive.writestr(f"{dist_info}/METADATA", _metadata())
+        archive.writestr(f"{dist_info}/WHEEL", _wheel_file())
+        archive.writestr(f"{dist_info}/RECORD", "")
+
+    return filename
+
+
+def build_sdist(
+    sdist_directory: str,
+    config_settings: Mapping[str, Sequence[str]] | None = None,
+) -> str:
+    sdist_dir = Path(sdist_directory)
+    sdist_dir.mkdir(parents=True, exist_ok=True)
+    filename = f"{_NAME}-{_VERSION}.tar.gz"
+    sdist_path = sdist_dir / filename
+
+    with tarfile.open(sdist_path, "w:gz") as archive:
+        info = tarfile.TarInfo(name=f"{_NAME}-{_VERSION}/PKG-INFO")
+        data = _metadata().encode("utf-8")
+        info.size = len(data)
+        archive.addfile(info, io.BytesIO(data))
+
+    return filename
+
+
+def build_editable(
+    wheel_directory: str,
+    config_settings: Mapping[str, Sequence[str]] | None = None,
+    metadata_directory: str | None = None,
+) -> str:
+    return build_wheel(wheel_directory, config_settings, metadata_directory)
+
+
+def get_requires_for_build_editable(
+    config_settings: Mapping[str, Sequence[str]] | None = None,
+) -> list[str]:
+    return []

--- a/cantao_solax_placeholder/__init__.py
+++ b/cantao_solax_placeholder/__init__.py
@@ -1,0 +1,3 @@
+"""Placeholder package for CI compatibility."""
+
+__all__: list[str] = []

--- a/contao/dca/tl_settings.php
+++ b/contao/dca/tl_settings.php
@@ -97,22 +97,22 @@ $GLOBALS['TL_DCA']['tl_settings']['fields']['solax_api_version'] = [
 
 $GLOBALS['TL_DCA']['tl_settings']['fields']['solax_api_key'] = [
     'label' => &$GLOBALS['TL_LANG']['tl_settings']['solax_api_key'],
-    'inputType' => 'text',
-    'eval' => ['maxlength' => 255, 'tl_class' => 'w50'],
+    'inputType' => 'password',
+    'eval' => ['maxlength' => 255, 'tl_class' => 'w50', 'encrypt' => true, 'hideInput' => true, 'alwaysSave' => true],
     'sql' => "varchar(255) NOT NULL default ''",
 ];
 
 $GLOBALS['TL_DCA']['tl_settings']['fields']['solax_serial_number'] = [
     'label' => &$GLOBALS['TL_LANG']['tl_settings']['solax_serial_number'],
-    'inputType' => 'text',
-    'eval' => ['maxlength' => 255, 'tl_class' => 'w50'],
+    'inputType' => 'password',
+    'eval' => ['maxlength' => 255, 'tl_class' => 'w50', 'encrypt' => true, 'hideInput' => true, 'alwaysSave' => true],
     'sql' => "varchar(255) NOT NULL default ''",
 ];
 
 $GLOBALS['TL_DCA']['tl_settings']['fields']['solax_site_id'] = [
     'label' => &$GLOBALS['TL_LANG']['tl_settings']['solax_site_id'],
-    'inputType' => 'text',
-    'eval' => ['maxlength' => 255, 'tl_class' => 'w50'],
+    'inputType' => 'password',
+    'eval' => ['maxlength' => 255, 'tl_class' => 'w50', 'encrypt' => true, 'hideInput' => true, 'alwaysSave' => true],
     'sql' => "varchar(255) NOT NULL default ''",
 ];
 

--- a/contao/languages/de/tl_settings.php
+++ b/contao/languages/de/tl_settings.php
@@ -23,9 +23,9 @@ $GLOBALS['TL_LANG']['tl_settings']['solax_fake_household_load'] = ['Grundlast Ha
 
 $GLOBALS['TL_LANG']['tl_settings']['solax_base_url'] = ['Solax API-Basis-URL', 'Basisadresse der Solax-Cloud-API.'];
 $GLOBALS['TL_LANG']['tl_settings']['solax_api_version'] = ['API-Version', 'Auswahl zwischen Solax Cloud API v1 und v2.'];
-$GLOBALS['TL_LANG']['tl_settings']['solax_api_key'] = ['API-Schlüssel', 'Persönlicher API-Schlüssel für Ihr Solax-Cloud-Konto.'];
-$GLOBALS['TL_LANG']['tl_settings']['solax_serial_number'] = ['Wechselrichter-Seriennummer', 'Seriennummer des Solax-Wechselrichters.'];
-$GLOBALS['TL_LANG']['tl_settings']['solax_site_id'] = ['Anlagen-/UID', 'Optionale Anlagen-ID bzw. UID, abhängig von der API-Version.'];
+$GLOBALS['TL_LANG']['tl_settings']['solax_api_key'] = ['API-Schlüssel', 'Persönlicher API-Schlüssel für Ihr Solax-Cloud-Konto (wird verschlüsselt gespeichert).'];
+$GLOBALS['TL_LANG']['tl_settings']['solax_serial_number'] = ['Wechselrichter-Seriennummer', 'Seriennummer des Solax-Wechselrichters (wird verschlüsselt gespeichert).'];
+$GLOBALS['TL_LANG']['tl_settings']['solax_site_id'] = ['Anlagen-/UID', 'Optionale Anlagen-ID bzw. UID (wird verschlüsselt gespeichert).'];
 $GLOBALS['TL_LANG']['tl_settings']['solax_timeout'] = ['Timeout (s)', 'Maximale Wartezeit in Sekunden auf eine Antwort der Solax-API.'];
 $GLOBALS['TL_LANG']['tl_settings']['solax_retry_count'] = ['Anzahl Wiederholungen', 'Wie oft fehlgeschlagene Solax-Anfragen erneut versucht werden.'];
 $GLOBALS['TL_LANG']['tl_settings']['solax_retry_delay'] = ['Wartezeit zwischen Versuchen (ms)', 'Pause in Millisekunden zwischen den Wiederholungsversuchen.'];

--- a/contao/languages/en/tl_settings.php
+++ b/contao/languages/en/tl_settings.php
@@ -23,9 +23,9 @@ $GLOBALS['TL_LANG']['tl_settings']['solax_fake_household_load'] = ['Base househo
 
 $GLOBALS['TL_LANG']['tl_settings']['solax_base_url'] = ['Solax API base URL', 'Endpoint of the Solax Cloud API.'];
 $GLOBALS['TL_LANG']['tl_settings']['solax_api_version'] = ['API version', 'Choose between Solax Cloud API v1 or v2.'];
-$GLOBALS['TL_LANG']['tl_settings']['solax_api_key'] = ['API key', 'Personal API key for your Solax Cloud account.'];
-$GLOBALS['TL_LANG']['tl_settings']['solax_serial_number'] = ['Inverter serial number', 'Serial number of the Solax inverter.'];
-$GLOBALS['TL_LANG']['tl_settings']['solax_site_id'] = ['Site/Plant ID or UID', 'Optional plant identifier required by some API versions.'];
+$GLOBALS['TL_LANG']['tl_settings']['solax_api_key'] = ['API key', 'Personal API key for your Solax Cloud account (stored encrypted).'];
+$GLOBALS['TL_LANG']['tl_settings']['solax_serial_number'] = ['Inverter serial number', 'Serial number of the Solax inverter (stored encrypted).'];
+$GLOBALS['TL_LANG']['tl_settings']['solax_site_id'] = ['Site/Plant ID or UID', 'Optional plant identifier required by some API versions (stored encrypted).'];
 $GLOBALS['TL_LANG']['tl_settings']['solax_timeout'] = ['Timeout (s)', 'Maximum time in seconds to wait for the Solax API response.'];
 $GLOBALS['TL_LANG']['tl_settings']['solax_retry_count'] = ['Retry count', 'Number of retries after a failed Solax API request.'];
 $GLOBALS['TL_LANG']['tl_settings']['solax_retry_delay'] = ['Retry delay (ms)', 'Delay in milliseconds between retry attempts.'];

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -63,8 +63,10 @@ innerhalb des PHP- und Contao-Stacks; zusätzliche Python-Tools sind nicht erfor
 - In **System → Einstellungen → Solax Fake-Daten** aktivieren Sie bei Bedarf den Fake-Data-Modus und passen Standort,
   Peakleistung sowie Wolkenvariabilität an. Die simulierten Werte orientieren sich an Sonnenauf- und -untergang sowie
   einer einfachen Wolkensimulation.
-- Unter **System → Einstellungen → Solax Zugangsdaten** tragen Sie die echten API-Zugangsdaten ein. Sobald diese vollständig
-  sind und der Fake-Data-Modus deaktiviert ist, verwendet der Cronjob automatisch Live-Daten der Solax-Cloud.
+- Unter **System → Einstellungen → Solax Zugangsdaten** tragen Sie die echten API-Zugangsdaten ein. API-Key, Seriennummer und
+  Plant-ID/UID werden dabei verschlüsselt gespeichert, sodass keine sensiblen Werte in Konfigurationsdateien landen. Sobald die
+  Zugangsdaten vollständig sind und der Fake-Data-Modus deaktiviert ist, verwendet der Cronjob automatisch Live-Daten der
+  Solax-Cloud.
 - Sind weder Zugangsdaten hinterlegt noch der Fake-Data-Modus aktiv, protokolliert der Cronjob einen entsprechenden Hinweis und
   überspringt den Lauf.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,3 @@
 requires = []
 build-backend = "cantao_build_backend"
 backend-path = ["."]
-
-[project]
-name = "cantao-solax-bundle"
-version = "0.0.0"
-description = "Placeholder package so CI 'pip install .' succeeds for the PHP bundle."
-readme = "README.md"
-license = {text = "MIT"}
-requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = []
+build-backend = "cantao_build_backend"
+backend-path = ["."]
+
+[project]
+name = "cantao-solax-bundle"
+version = "0.0.0"
+description = "Placeholder package so CI 'pip install .' succeeds for the PHP bundle."
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.10"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+from distutils.core import setup
+
+README = Path(__file__).with_name("README.md")
+
+setup(
+    name="cantao-solax-bundle",
+    version="0.0.0",
+    description="Placeholder package so CI 'pip install .' succeeds for the PHP bundle.",
+    long_description=README.read_text(encoding="utf-8") if README.exists() else "",
+)

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,17 @@
 from pathlib import Path
-from distutils.core import setup
 
-README = Path(__file__).with_name("README.md")
+from setuptools import setup
+
+BASE_DIR = Path(__file__).resolve().parent
+README = BASE_DIR / "README.md"
 
 setup(
     name="cantao-solax-bundle",
     version="0.0.0",
     description="Placeholder package so CI 'pip install .' succeeds for the PHP bundle.",
     long_description=README.read_text(encoding="utf-8") if README.exists() else "",
+    long_description_content_type="text/markdown",
+    license="MIT",
+    packages=["cantao_solax_placeholder"],
+    python_requires=">=3.10",
 )


### PR DESCRIPTION
## Summary
- store Solax API credentials via password fields in the Contao settings so values are saved encrypted
- document the encrypted backend configuration workflow in the README and integration guide
- add a lightweight Python packaging stub with a custom build backend so that `pip install .` in CI succeeds

## Testing
- python -m pip install .

------
https://chatgpt.com/codex/tasks/task_e_68ecb2fa303c8327851c7ba5894c0406