### PR TITLE
Allow installation with Symfony 7 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
-        "symfony/http-client": "^6.0",
-        "symfony/dependency-injection": "^6.0",
-        "symfony/config": "^6.0",
-        "symfony/http-kernel": "^6.0",
+        "symfony/http-client": "^6.0 || ^7.0",
+        "symfony/dependency-injection": "^6.0 || ^7.0",
+        "symfony/config": "^6.0 || ^7.0",
+        "symfony/http-kernel": "^6.0 || ^7.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "contao/core-bundle": "^5.0"
     },


### PR DESCRIPTION
## Summary
- allow the bundle to install alongside Symfony 7 by widening the supported versions of the required HttpClient, DependencyInjection, Config, and HttpKernel components

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68ecb87227108327930cc93705456ea1