### PR TITLE
Fix configuration tree for API version

### DIFF
--- a/php-src/DependencyInjection/Configuration.php
+++ b/php-src/DependencyInjection/Configuration.php
@@ -24,6 +24,7 @@ class Configuration implements ConfigurationInterface
                             ->ifNotInArray(['v1', 'v2'])
                             ->thenInvalid('Solax API version must be either "v1" or "v2".')
                         ->end()
+                        ->end()
                         ->scalarNode('api_key')->defaultNull()->end()
                         ->scalarNode('serial_number')->defaultNull()->end()
                         ->scalarNode('site_id')->defaultNull()->end()


### PR DESCRIPTION
## Summary
- add the missing node terminator for the API version configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ecbc374ff883279de64aee5c3ee37d