### PR TITLE
Add coverage for Solax fake and real data handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,16 @@
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "contao/core-bundle": "^5.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6"
+    },
     "autoload": {
         "psr-4": {
             "Cantao\\SolaxBundle\\": "php-src/"
         }
+    },
+    "scripts": {
+        "test": "phpunit"
     },
     "extra": {
         "contao-manager-plugin": "Cantao\\SolaxBundle\\ContaoManager\\Plugin"

--- a/php-src/Service/FakeDataGenerator.php
+++ b/php-src/Service/FakeDataGenerator.php
@@ -18,10 +18,10 @@ class FakeDataGenerator
     /**
      * @return array<string, float|int>
      */
-    public function generate(): array
+    public function generate(?DateTimeImmutable $now = null): array
     {
         $settings = $this->configurationProvider->getFakeDataSettings();
-        $now = new DateTimeImmutable('now');
+        $now = $now ?? new DateTimeImmutable('now');
         $sunTimes = $this->resolveSunTimes($now, $settings['latitude'] ?? 0.0, $settings['longitude'] ?? 0.0);
         $timestamp = $now->getTimestamp();
         $sunrise = $sunTimes['sunrise'];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         colors="true"
+         backupGlobals="false"
+         backupStaticAttributes="false">
+    <testsuites>
+        <testsuite name="Cantao Solax Bundle Tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Service/FakeDataGeneratorTest.php
+++ b/tests/Service/FakeDataGeneratorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cantao\SolaxBundle\Tests\Service;
+
+use Cantao\SolaxBundle\Service\FakeDataGenerator;
+use Cantao\SolaxBundle\Service\SolaxConfigurationProvider;
+use DateTimeImmutable;
+use DateTimeZone;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class FakeDataGeneratorTest extends TestCase
+{
+    public function testGeneratesDaytimeMetricsWithClouds(): void
+    {
+        $configProvider = $this->createMock(SolaxConfigurationProvider::class);
+        $configProvider->method('getFakeDataSettings')->willReturn([
+            'latitude' => 0.0,
+            'longitude' => 0.0,
+            'peak_power' => 5000.0,
+            'base_total_yield' => 2000.0,
+            'cloud_variability' => 0.5,
+            'household_base_load' => 600.0,
+        ]);
+
+        $generator = new FakeDataGenerator($configProvider, new NullLogger());
+        $noon = new DateTimeImmutable('2024-06-21 12:00:00', new DateTimeZone('UTC'));
+
+        $metrics = $generator->generate($noon);
+
+        self::assertArrayHasKey('acpower', $metrics);
+        self::assertArrayHasKey('cloud_coverage', $metrics);
+        self::assertGreaterThan(0.0, $metrics['acpower']);
+        self::assertGreaterThan(0.0, $metrics['yieldtoday']);
+        self::assertGreaterThanOrEqual(0.0, $metrics['cloud_coverage']);
+        self::assertLessThanOrEqual(0.5, $metrics['cloud_coverage']);
+    }
+
+    public function testGeneratesNighttimeMetricsWithoutProduction(): void
+    {
+        $configProvider = $this->createMock(SolaxConfigurationProvider::class);
+        $configProvider->method('getFakeDataSettings')->willReturn([
+            'latitude' => 0.0,
+            'longitude' => 0.0,
+            'peak_power' => 5000.0,
+            'base_total_yield' => 2000.0,
+            'cloud_variability' => 0.5,
+            'household_base_load' => 600.0,
+        ]);
+
+        $generator = new FakeDataGenerator($configProvider, new NullLogger());
+        $night = new DateTimeImmutable('2024-06-21 23:30:00', new DateTimeZone('UTC'));
+
+        $metrics = $generator->generate($night);
+
+        self::assertEqualsWithDelta(0.0, $metrics['acpower'], 0.01);
+        self::assertSame(0.0, $metrics['yieldtoday']);
+        self::assertGreaterThan(0.0, $metrics['consumeenergy']);
+    }
+}

--- a/tests/Service/SolaxClientTest.php
+++ b/tests/Service/SolaxClientTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cantao\SolaxBundle\Tests\Service;
+
+use Cantao\SolaxBundle\Service\SolaxClient;
+use Cantao\SolaxBundle\Service\SolaxConfigurationProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class SolaxClientTest extends TestCase
+{
+    public function testFetchRealtimeDataReturnsPayloadAndBuildsRequest(): void
+    {
+        $capturedUrl = null;
+        $capturedOptions = null;
+
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options = []) use (&$capturedUrl, &$capturedOptions): MockResponse {
+            $capturedUrl = $url;
+            $capturedOptions = $options;
+
+            return new MockResponse(json_encode(['result' => ['acpower' => 123]]));
+        });
+
+        $configProvider = $this->createMock(SolaxConfigurationProvider::class);
+        $configProvider->method('getSolaxConfig')->willReturn([
+            'base_url' => 'https://www.solaxcloud.com:9443',
+            'api_version' => 'v1',
+            'api_key' => 'token',
+            'serial_number' => 'sn123',
+            'site_id' => 'plant-1',
+            'timeout' => 10,
+            'retry_count' => 0,
+        ]);
+
+        $client = new SolaxClient($httpClient, new NullLogger(), $configProvider);
+        $data = $client->fetchRealtimeData();
+
+        self::assertSame(['acpower' => 123], $data);
+        self::assertNotNull($capturedUrl);
+        self::assertStringContainsString('/api/v1/getRealtimeInfo', $capturedUrl);
+        self::assertNotNull($capturedOptions);
+        self::assertSame(
+            [
+                'sn' => 'sn123',
+                'tokenId' => 'token',
+                'plantId' => 'plant-1',
+            ],
+            $capturedOptions['query'] ?? []
+        );
+    }
+
+    public function testMissingCredentialsThrowsRuntimeException(): void
+    {
+        $httpClient = new MockHttpClient(new MockResponse('[]'));
+        $configProvider = $this->createMock(SolaxConfigurationProvider::class);
+        $configProvider->method('getSolaxConfig')->willReturn([
+            'base_url' => 'https://www.solaxcloud.com:9443',
+            'api_version' => 'v1',
+            'api_key' => null,
+            'serial_number' => null,
+        ]);
+
+        $client = new SolaxClient($httpClient, new NullLogger(), $configProvider);
+
+        $this->expectException(\RuntimeException::class);
+        $client->fetchRealtimeData();
+    }
+}


### PR DESCRIPTION
## Summary
- allow passing a custom timestamp into the fake data generator so behavior is testable for day and night scenarios
- add PHPUnit-based coverage for simulated metrics and Solax client request handling to validate fake and real data paths
- declare phpunit as a dev dependency and expose a composer test script for running the suite

## Testing
- composer install --no-interaction *(fails in CI container: CONNECT tunnel failed, response 403)*
- phpunit *(not run; composer install failed)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921ee8221448327a9785235feca2446)